### PR TITLE
X3-125503 : AdxAdmin uninstallation cryptic error message

### DIFF
--- a/bin/langpacks/installer/deu.xml
+++ b/bin/langpacks/installer/deu.xml
@@ -49,6 +49,9 @@
     <str id="uninstaller.warning" txt="Jetzt werden die installierten Anwendungen entfernt!"/>
     <str id="uninstaller.destroytarget" txt="Lösche alle Dateien in "/>
     <str id="uninstaller.uninstall" txt="Deinstallieren"/>
+    <str id="uninstaller.adxadmin.remainingmodules" txt="Deinstallation nicht möglich: einige Komponenten sind noch installiert."/>
+    <str id="uninstaller.adxadmin.errparseadxinstall" txt="Deinstallation nicht möglich: Analysefehler in adxinstall.xml"/>
+
 
     <!-- The strings for the 'official' IzPack plugins -->
     <str id="HelloPanel.welcome1" txt="Willkommen zur Installation von "/>

--- a/bin/langpacks/installer/eng.xml
+++ b/bin/langpacks/installer/eng.xml
@@ -55,6 +55,9 @@
     <str id="uninstaller.warning" txt="This will remove the installed application!"/>
     <str id="uninstaller.destroytarget" txt=" Force the deletion of "/>
     <str id="uninstaller.uninstall" txt="Uninstall"/>
+    <str id="uninstaller.adxadmin.remainingmodules" txt="Uninstallation impossible : some composants are still installed."/>
+    <str id="uninstaller.adxadmin.errparseadxinstall" txt="Uninstallation impossible : parsing error on adxinstall.xml"/>
+
 
     <!-- The strings for the 'official' IzPack plugins -->
     <!-- HelloPanel strings -->
@@ -135,6 +138,7 @@
     <str id="InstallPanel.overwrite.title" txt="File already exists"/>
     <str id="InstallPanel.overwrite.question" txt="The following file already exists. Should it be overwritten?"/>
 
+					
 		<!-- InstallationGroupPanel strings -->
 		<str id="InstallationGroupPanel.colNameSelected" txt="Selected"/>
     <str id="InstallationGroupPanel.colNameInstallType" txt="InstallType"/>

--- a/bin/langpacks/installer/eng.xml
+++ b/bin/langpacks/installer/eng.xml
@@ -55,8 +55,8 @@
     <str id="uninstaller.warning" txt="This will remove the installed application!"/>
     <str id="uninstaller.destroytarget" txt=" Force the deletion of "/>
     <str id="uninstaller.uninstall" txt="Uninstall"/>
-    <str id="uninstaller.adxadmin.remainingmodules" txt="Uninstallation impossible : some composants are still installed."/>
-    <str id="uninstaller.adxadmin.errparseadxinstall" txt="Uninstallation impossible : parsing error on adxinstall.xml"/>
+    <str id="uninstaller.adxadmin.remainingmodules" txt="Uninstallation impossible: some components are still installed."/>
+    <str id="uninstaller.adxadmin.errparseadxinstall" txt="Uninstallation impossible: parsing error on adxinstall.xml"/>
 
 
     <!-- The strings for the 'official' IzPack plugins -->

--- a/bin/langpacks/installer/fra.xml
+++ b/bin/langpacks/installer/fra.xml
@@ -55,8 +55,8 @@
     <str id="uninstaller.warning" txt="Ceci va enlever l'(es) application(s) installée(s) !"/>
     <str id="uninstaller.destroytarget" txt=" Forcer la suppression de : "/>
     <str id="uninstaller.uninstall" txt="Désinstaller"/>
-    <str id="uninstaller.adxadmin.remainingmodules" txt="Désinstallation impossible: il reste des composants installés."/>
-    <str id="uninstaller.adxadmin.errparseadxinstall" txt="Désinstallation impossible: Erreur de modification de l'adxinstall.xml"/>
+    <str id="uninstaller.adxadmin.remainingmodules" txt="Désinstallation impossible : il reste des composants installés."/>
+    <str id="uninstaller.adxadmin.errparseadxinstall" txt="Désinstallation impossible : erreur de modification de l'adxinstall.xml"/>
 
 
 		<!-- The strings for the 'official' IzPack plugins -->

--- a/bin/langpacks/installer/fra.xml
+++ b/bin/langpacks/installer/fra.xml
@@ -55,6 +55,9 @@
     <str id="uninstaller.warning" txt="Ceci va enlever l'(es) application(s) installée(s) !"/>
     <str id="uninstaller.destroytarget" txt=" Forcer la suppression de : "/>
     <str id="uninstaller.uninstall" txt="Désinstaller"/>
+    <str id="uninstaller.adxadmin.remainingmodules" txt="Désinstallation impossible: il reste des composants installés."/>
+    <str id="uninstaller.adxadmin.errparseadxinstall" txt="Désinstallation impossible: Erreur de modification de l'adxinstall.xml"/>
+
 
 		<!-- The strings for the 'official' IzPack plugins -->
     <!-- HelloPanel strings -->

--- a/bin/langpacks/installer/pol.xml
+++ b/bin/langpacks/installer/pol.xml
@@ -194,9 +194,13 @@
 	<str id="TargetPanel.summaryCaption" txt="Katalog docelowy"/>
 	<str id="TargetPanel.warn" txt="Katalog już istnieje! Czy jesteś pewien, że chcesz kontynuować instalację i nadpisać istniejące pliki?"/>
 	<str id="TreePacksPanel.summaryCaption" txt="Wybrane pakiety"/>
+
 	<str id="uninstaller.destroytarget" txt=" Wymuś usunięcie "/>
 	<str id="uninstaller.uninstall" txt="Odinstaluj"/>
 	<str id="uninstaller.warning" txt="Umożliwia usunięcie zainstalowanego oprogramowania!"/>
+    <str id="uninstaller.adxadmin.remainingmodules" txt="Nie można odinstalować – niektóre składniki są cały czas zainstalowane."/>
+    <str id="uninstaller.adxadmin.errparseadxinstall" txt="Nie można odinstalować – błąd parsowania w adxinstall.xml."/>
+
 	<str id="UserInputPanel.dir.nodirectory.caption" txt="Nie wybrano żadnego katalogu"/>
 	<str id="UserInputPanel.dir.nodirectory.message" txt="Musisz wybrać prawidłowy katalog."/>
 	<str id="UserInputPanel.dir.notdirectory.caption" txt="Nieprawidłowy katalog"/>

--- a/bin/langpacks/installer/spa.xml
+++ b/bin/langpacks/installer/spa.xml
@@ -49,6 +49,9 @@
     <str id="uninstaller.warning" txt="¡Se eliminarán la(s) aplicacion(es) instalada(s)!"/>
     <str id="uninstaller.destroytarget" txt=" Forzar la eliminación de "/>
     <str id="uninstaller.uninstall" txt="Desinstalar"/>
+    <str id="uninstaller.adxadmin.remainingmodules" txt="No se puede desinstalar. Algunos componentes siguen instalados."/>
+    <str id="uninstaller.adxadmin.errparseadxinstall" txt="No se puede desinstalar. Error al analizar adxinstall.xml."/>
+
 
     <!-- The strings for the 'official' IzPack plugins -->
     <str id="HelloPanel.welcome1" txt="Bienvenido a la instalación de "/>


### PR DESCRIPTION
Add missing resource "uninstaller.adxadmin.remainingmodules"
release/4.3.8

http://ptf-ci-master2.sagefr.adinternal.com:8080/job/IzPack-Build-Docker/job/release%252F4.3.8/
