### PR TITLE
feature(X3-293749): add hostname validator without port checking

### DIFF
--- a/izPackCustomActions/build.xml
+++ b/izPackCustomActions/build.xml
@@ -181,6 +181,7 @@
             <include name="FinishNewPanelAutomationHelper.java"/>
             <include name="FinishNewPanelValidator.java"/>
             <include name="HexaPassphraseProcessor.java"/>
+            <include name="HostnameValidator.java"/>
             <include name="InstallTypeNewPanel.java"/>
             <include name="InstallTypeNewPanelAutomationHelper.java"/>
             <include name="InstallationInformationHelper.java"/>

--- a/izPackCustomActions/src/com/sage/izpack/HostnameValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/HostnameValidator.java
@@ -1,0 +1,29 @@
+package com.sage.izpack;
+
+import java.net.InetAddress;
+
+import com.izforge.izpack.panels.userinput.processorclient.ProcessingClient;
+import com.izforge.izpack.panels.userinput.validator.Validator;
+
+public class HostnameValidator implements Validator {
+
+	@Override
+	public boolean validate(ProcessingClient client) {
+		String host = "";
+		boolean retValue = true;
+
+		try {
+			host = client.getFieldContents(0);
+		} catch (Exception e) {
+			return false;
+		}
+
+		try {
+			InetAddress.getByName(host);
+		} catch (Exception ex) {
+			retValue = false;
+		}
+		return retValue;
+	}
+
+}


### PR DESCRIPTION
previously used HostAddressValidator changed its implementation between izpack 4->5, from checking hostname to checking hostname:port. adding validator with old behaviour (only checks hostname).