### PR TITLE
fix(X3-282787): fix syracuse unattended installation

### DIFF
--- a/izPackCustomActions/build.xml
+++ b/izPackCustomActions/build.xml
@@ -191,6 +191,7 @@
             <include name="InstallTypeNewPanelAutomationHelper.java"/>
             <include name="InstallationTypePanelAutomationHelper.java"/>
             <include name="InstallationInformationHelper.java"/>
+            <include name="ModifyInstallationUtil.java"/>
             <include name="NodeIdentifierValidator.java"/>
             <include name="NodeIdentifierDataValidator.java"/>
             <include name="OsVersionHelper.java"/>			

--- a/izPackCustomActions/src/com/sage/izpack/AdxCompInstallerListener.java
+++ b/izPackCustomActions/src/com/sage/izpack/AdxCompInstallerListener.java
@@ -150,7 +150,7 @@ public class AdxCompInstallerListener extends AbstractInstallerListener implemen
 			// String version = moduleSpec.getFirstChildNamed("component." +
 			// moduleFamily.toLowerCase() + ".version").getContent();
 
-			boolean modifyinstallation = Boolean.valueOf(installData.getVariable(InstallData.MODIFY_INSTALLATION));
+			boolean modifyinstallation = ModifyInstallationUtil.get(installData);
 
 			logger.log(Level.FINE, LogPrefix + "afterPacks  moduleName: " + moduleName + " moduleFamily: "
 					+ moduleFamily + " modifyinstallation: " + modifyinstallation);

--- a/izPackCustomActions/src/com/sage/izpack/CertManagerDataValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/CertManagerDataValidator.java
@@ -75,6 +75,13 @@ public class CertManagerDataValidator implements DataValidator {
 				if (certCreate) {
 					certCreate(adata);
 					hostname = adata.getVariable("syracuse.certificate.hostname").toLowerCase();
+
+					// set for mongodb install
+					adata.setVariable("mongodb.ssl.server.certfile",
+							strCertPath + File.separator + localHOST_NAME + ".crt");
+					adata.setVariable("mongodb.ssl.server.pemkeyfile",
+							strCertPath + File.separator + localHOST_NAME + ".key");
+					adata.setVariable("mongodb.ssl.server.pemcafile", strCertPath + File.separator + "ca.cacrt");
 				} else {
 
 					adata.setVariable("syracuse.certificate.certtool", adata.getVariable("INSTALL_PATH")
@@ -98,16 +105,7 @@ public class CertManagerDataValidator implements DataValidator {
                     
                     adata.setVariable("syracuse.certificate.serverpassphrase",adata.getVariable("syracuse.ssl.pemkeypassword"));
 				}
-
-				// set for mongodb install
-				adata.setVariable("mongodb.ssl.server.serverpassphrase",
-						adata.getVariable("syracuse.certificate.serverpassphrase"));
-				adata.setVariable("mongodb.ssl.server.certfile",
-						strCertPath + File.separator + localHOST_NAME + ".crt");
-				adata.setVariable("mongodb.ssl.server.pemkeyfile",
-						strCertPath + File.separator + localHOST_NAME + ".key");
-				adata.setVariable("mongodb.ssl.server.pemcafile", strCertPath + File.separator + "ca.cacrt");
-
+				adata.setVariable("mongodb.ssl.server.serverpassphrase", adata.getVariable("syracuse.certificate.serverpassphrase"));
 			}
 
 			if (mongoSSL) {
@@ -205,11 +203,6 @@ public class CertManagerDataValidator implements DataValidator {
 		}
 
 		KeyPairGeneratorDataValidator.mergeFiles(new File[] { certsServerCRT, certsServerKey }, certsServerPem);
-
-		// set variables for future use
-		adata.setVariable("mongodb.ssl.client.certfile", strCertPath + File.separator + "client.crt");
-		adata.setVariable("mongodb.ssl.client.pemkeyfile", strCertPath + File.separator + "client.key");
-		adata.setVariable("mongodb.ssl.pemcafile", strCertPath + File.separator + "ca.cacrt");
 	}
 
 	public void clientCertCreate(InstallData adata) throws Exception {
@@ -252,12 +245,6 @@ public class CertManagerDataValidator implements DataValidator {
 		KeyPairGeneratorDataValidator.writePrivateKey(strCertPath + File.separator + "client.key", pairClient, null);
 
 		KeyPairGeneratorDataValidator.mergeFiles(new File[] { certsServerCRT, certsServerKey }, certsServerPem);
-
-		// set variables for future use
-		adata.setVariable("mongodb.ssl.client.certfile", strCertPath + File.separator + "client.crt");
-		adata.setVariable("mongodb.ssl.client.pemkeyfile", strCertPath + File.separator + "client.key");
-		adata.setVariable("mongodb.ssl.pemcafile", strCertPath + File.separator + "ca.cacrt");
-
 	}
 
 	public void readCerts(InstallData adata) throws Exception {

--- a/izPackCustomActions/src/com/sage/izpack/CertManagerDataValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/CertManagerDataValidator.java
@@ -57,7 +57,7 @@ public class CertManagerDataValidator implements DataValidator {
 	@Override
 	public Status validateData(InstallData adata) {
 
-		Boolean modifyinstallation = Boolean.valueOf(adata.getVariable(InstallData.MODIFY_INSTALLATION));
+		Boolean modifyinstallation = ModifyInstallationUtil.get(adata);
 		Boolean mongoSSL = Boolean.valueOf(adata.getVariable("mongodb.ssl.enable"));
 
 		Status statusReturn = Status.OK;

--- a/izPackCustomActions/src/com/sage/izpack/CheckProductAlreadyInstalled.java
+++ b/izPackCustomActions/src/com/sage/izpack/CheckProductAlreadyInstalled.java
@@ -62,7 +62,7 @@ public class CheckProductAlreadyInstalled implements DataValidator {
 						RegDataContainer oldInstallPath = registryHandler.getValue(RegistryHandler.UNINSTALL_ROOT + line, "DisplayIcon");
 						String path = oldInstallPath.getStringData().substring(0, oldInstallPath.getStringData().indexOf("Uninstaller") - 1);
 						installData.setInstallPath(path);
-						installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
+						ModifyInstallationUtil.set(installData, Boolean.TRUE);;
 						logger.log(Level.FINE, "CheckProductAlreadyInstalled  Detected path: " + path);
 						
 						//  INSTALLER_GUI = 0, INSTALLER_AUTO = 1, INSTALLER_CONSOLE = 2;

--- a/izPackCustomActions/src/com/sage/izpack/CheckedHelloNewPanel.java
+++ b/izPackCustomActions/src/com/sage/izpack/CheckedHelloNewPanel.java
@@ -234,7 +234,7 @@ public class CheckedHelloNewPanel extends CheckedHelloPanel {
 			if (result) {
 				// Set variable "modify.izpack.install"
 				installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
-				installData.setVariable(InstallData.MODIFY_INSTALLATION.toLowerCase(), "true");
+				installData.setVariable(InstallData.MODIFY_INSTALLATION.toUpperCase(), "true");
 			}
 			logger.log(Level.FINE,
 					logPrefix + "isRegistered()  Set " + InstallData.MODIFY_INSTALLATION + ": " + result);

--- a/izPackCustomActions/src/com/sage/izpack/CheckedHelloNewPanel.java
+++ b/izPackCustomActions/src/com/sage/izpack/CheckedHelloNewPanel.java
@@ -233,8 +233,7 @@ public class CheckedHelloNewPanel extends CheckedHelloPanel {
 			}
 			if (result) {
 				// Set variable "modify.izpack.install"
-				installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
-				installData.setVariable(InstallData.MODIFY_INSTALLATION.toUpperCase(), "true");
+				ModifyInstallationUtil.set(installData, Boolean.TRUE);
 			}
 			logger.log(Level.FINE,
 					logPrefix + "isRegistered()  Set " + InstallData.MODIFY_INSTALLATION + ": " + result);

--- a/izPackCustomActions/src/com/sage/izpack/CheckedHelloNewPanel.java
+++ b/izPackCustomActions/src/com/sage/izpack/CheckedHelloNewPanel.java
@@ -234,6 +234,7 @@ public class CheckedHelloNewPanel extends CheckedHelloPanel {
 			if (result) {
 				// Set variable "modify.izpack.install"
 				installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
+				installData.setVariable(InstallData.MODIFY_INSTALLATION.toLowerCase(), "true");
 			}
 			logger.log(Level.FINE,
 					logPrefix + "isRegistered()  Set " + InstallData.MODIFY_INSTALLATION + ": " + result);

--- a/izPackCustomActions/src/com/sage/izpack/InstallTypeNewConsolePanel.java
+++ b/izPackCustomActions/src/com/sage/izpack/InstallTypeNewConsolePanel.java
@@ -46,19 +46,22 @@ public class InstallTypeNewConsolePanel extends com.izforge.izpack.installer.con
 	@Override
 	public boolean run(InstallData installData, Properties p) {
 
-		String strType = p.getProperty(InstallData.MODIFY_INSTALLATION).trim();
+		String strType = p.getProperty(InstallData.MODIFY_INSTALLATION.toUpperCase()).trim();
+		if (strType == null || "".equals(strType)) {
+			strType = p.getProperty(InstallData.MODIFY_INSTALLATION.toLowerCase()).trim();
+		}
 		if (strType == null || "".equals(strType)) {
 			// assume a normal install
-			installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
+			ModifyInstallationUtil.set(installData, Boolean.FALSE);
 		} else {
 			if (Boolean.parseBoolean(strType)) {
 				// is a modify type install
-				installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
+				ModifyInstallationUtil.set(installData, Boolean.TRUE);
 				String strInstallpath = p.getProperty("installpath").trim();
 				installData.setInstallPath(strInstallpath);
 
 			} else {
-				installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
+				ModifyInstallationUtil.set(installData, Boolean.FALSE);
 			}
 		}
 		return true;
@@ -93,10 +96,10 @@ public class InstallTypeNewConsolePanel extends com.izforge.izpack.installer.con
 
 		switch (i) {
 		case 1:
-			installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
+			ModifyInstallationUtil.set(installData, Boolean.FALSE);
 			return true;
 		case 2:
-			installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
+			ModifyInstallationUtil.set(installData, Boolean.TRUE);
 			return chooseComponent(installData, console);
 		default:
 			// want to exit

--- a/izPackCustomActions/src/com/sage/izpack/InstallTypeNewPanel.java
+++ b/izPackCustomActions/src/com/sage/izpack/InstallTypeNewPanel.java
@@ -76,7 +76,7 @@ public class InstallTypeNewPanel extends IzPanel implements ActionListener, List
 
 		// boolean modifyinstallation =
 		// Boolean.valueOf(idata.getVariable(InstallData.MODIFY_INSTALLATION));
-		boolean modifyinstallation = Boolean.valueOf(this.installData.getVariable(InstallData.MODIFY_INSTALLATION));
+		boolean modifyinstallation = ModifyInstallationUtil.get(installData);
 
 		// normalinstall = new
 		// JRadioButton(parent.langpack.getString("InstallationTypePanel.normal"),
@@ -142,7 +142,7 @@ public class InstallTypeNewPanel extends IzPanel implements ActionListener, List
 			e.printStackTrace();
 		}
 
-		boolean modifyinstallation = Boolean.valueOf(this.installData.getVariable(InstallData.MODIFY_INSTALLATION));
+		boolean modifyinstallation = ModifyInstallationUtil.get(installData);
 
 		if (modifyinstallation) {
 			modifyinstall.setSelected(true);
@@ -178,14 +178,12 @@ public class InstallTypeNewPanel extends IzPanel implements ActionListener, List
 			installedComponents.clearSelection();
 
 			installedComponents.setEnabled(false);
-			// idata.setVariable(InstallData.MODIFY_INSTALLATION, "false");
-			this.installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
+			ModifyInstallationUtil.set(installData, Boolean.FALSE);
 		} else if (e.getSource() == modifyinstall) {
 			logger.log(Level.FINE, "InstallTypeNewPanel modification installation");
 			// Debug.trace("modification installation");
 			installedComponents.setEnabled(true);
-			// idata.setVariable(InstallData.MODIFY_INSTALLATION, "true");
-			this.installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
+			ModifyInstallationUtil.set(installData, Boolean.TRUE);
 
 			if (selectedKey != null) {
 				if (listItems.contains(selectedKey)) {
@@ -223,7 +221,7 @@ public class InstallTypeNewPanel extends IzPanel implements ActionListener, List
 	public boolean isValidated() {
 		// we must ensure .installinformation is present if in modification mode
 		// then set install_path
-		Boolean modifyinstallation = Boolean.valueOf(this.installData.getVariable(InstallData.MODIFY_INSTALLATION));
+		Boolean modifyinstallation = ModifyInstallationUtil.get(installData);
 
 		if (modifyinstallation) {
 
@@ -266,7 +264,7 @@ public class InstallTypeNewPanel extends IzPanel implements ActionListener, List
 	public String getSummaryBody() {
 
 		// if (Boolean.parseBoolean(idata.getVariable(InstallData.MODIFY_INSTALLATION)))
-		if (Boolean.parseBoolean(this.installData.getVariable(InstallData.MODIFY_INSTALLATION))) {
+		if (ModifyInstallationUtil.get(installData)) {
 			// return ResourcesHelper.getCustomPropString("InstallTypeNewPanel.modify");
 			return super.getString("InstallTypeNewPanel.modify");
 			// return parent.langpack.getString("InstallationTypePanel.modify");

--- a/izPackCustomActions/src/com/sage/izpack/InstallTypeNewPanelAutomation.java
+++ b/izPackCustomActions/src/com/sage/izpack/InstallTypeNewPanelAutomation.java
@@ -17,11 +17,7 @@ public class InstallTypeNewPanelAutomation implements PanelAutomation {
 		IXMLElement ipath = new XMLElementImpl(InstallData.MODIFY_INSTALLATION, panelRoot);
 		// check this writes even if value is the default,
 		// because without the constructor, default does not get set.
-		if (installData.getVariable(InstallData.MODIFY_INSTALLATION) != null) {
-			ipath.setContent(installData.getVariable(InstallData.MODIFY_INSTALLATION));
-		} else {
-			ipath.setContent(Boolean.FALSE.toString());
-		}
+		ipath.setContent(ModifyInstallationUtil.get(installData).toString());
 
 		IXMLElement prev = panelRoot.getFirstChildNamed(InstallData.MODIFY_INSTALLATION);
 		if (prev != null) {
@@ -45,27 +41,7 @@ public class InstallTypeNewPanelAutomation implements PanelAutomation {
 	public void runAutomated(InstallData installData, IXMLElement panelRoot) throws InstallerException {
 
 		// part of MODIFY_INSTALLATION
-		IXMLElement ipath = panelRoot.getFirstChildNamed(InstallData.MODIFY_INSTALLATION);
-
-		String modify = null;
-
-		try {
-			modify = ipath.getContent().trim();
-		} catch (Exception ex) {
-			// assume a normal install
-			installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
-		}
-
-		if (modify == null || "".equals(modify)) {
-			// assume a normal install
-			installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
-		} else {
-			if (Boolean.parseBoolean(modify)) {
-				installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
-			} else {
-				installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
-			}
-		}
+		ModifyInstallationUtil.set(installData, ModifyInstallationUtil.get(panelRoot));
 		// part of target path
 		IXMLElement ipath2 = panelRoot.getFirstChildNamed(INSTALLPATH);
 
@@ -94,8 +70,7 @@ public class InstallTypeNewPanelAutomation implements PanelAutomation {
 			modifyInstallation = overrides.fetch(InstallData.MODIFY_INSTALLATION.toUpperCase());
 		}
 		if (modifyInstallation != null) {
-			installData.setVariable(InstallData.MODIFY_INSTALLATION,
-					String.valueOf(Boolean.parseBoolean(modifyInstallation)));
+			ModifyInstallationUtil.set(installData, modifyInstallation);
 		}
 		String installpath = overrides.fetch(INSTALLPATH);
 		if (installpath != null) {

--- a/izPackCustomActions/src/com/sage/izpack/InstallationTypePanelAutomationHelper.java
+++ b/izPackCustomActions/src/com/sage/izpack/InstallationTypePanelAutomationHelper.java
@@ -16,11 +16,7 @@ public class InstallationTypePanelAutomationHelper extends PanelAutomationHelper
 		IXMLElement ipath = new XMLElementImpl(InstallData.MODIFY_INSTALLATION, panelRoot);
 		// check this writes even if value is the default,
 		// because without the constructor, default does not get set.
-		if (installData.getVariable(InstallData.MODIFY_INSTALLATION) != null) {
-			ipath.setContent(installData.getVariable(InstallData.MODIFY_INSTALLATION));
-		} else {
-			ipath.setContent(Boolean.FALSE.toString());
-		}
+		ipath.setContent(ModifyInstallationUtil.get(installData).toString());
 
 		IXMLElement prev = panelRoot.getFirstChildNamed(InstallData.MODIFY_INSTALLATION);
 		if (prev != null) {
@@ -32,28 +28,7 @@ public class InstallationTypePanelAutomationHelper extends PanelAutomationHelper
 
 	@Override
 	public void runAutomated(InstallData installData, IXMLElement panelRoot) throws InstallerException {
-		IXMLElement ipath = panelRoot.getFirstChildNamed(InstallData.MODIFY_INSTALLATION);
-
-		String modify = null;
-
-		try {
-			modify = ipath.getContent().trim();
-		} catch (Exception ex) {
-			// assume a normal install
-			installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
-		}
-
-		if (modify == null || "".equals(modify)) {
-			// assume a normal install
-			installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
-		} else {
-			if (Boolean.parseBoolean(modify)) {
-				installData.setVariable(InstallData.MODIFY_INSTALLATION, "true");
-			} else {
-				installData.setVariable(InstallData.MODIFY_INSTALLATION, "false");
-			}
-		}
-
+		ModifyInstallationUtil.set(installData, ModifyInstallationUtil.get(panelRoot));
 	}
 
 	@Override

--- a/izPackCustomActions/src/com/sage/izpack/ModifyInstallationUtil.java
+++ b/izPackCustomActions/src/com/sage/izpack/ModifyInstallationUtil.java
@@ -1,0 +1,39 @@
+package com.sage.izpack;
+
+import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.data.InstallData;
+
+/**
+ * In izpack4 {@link InstallData#MODIFY_INSTALLATION} variable was in upper case, in version 5 it got changed to lower case.
+ * This is util is for backward compatibility. It reads the variable with a fallback to izpack4.
+ */
+public abstract class ModifyInstallationUtil {
+	private static final String TRUE = "true";
+	private static final String FALSE = "false";
+
+	public static void set(InstallData data, boolean value) {
+		ModifyInstallationUtil.set(data, value ? TRUE : FALSE);
+	}
+
+	public static void set(InstallData data, String value) {
+		assert (TRUE.equalsIgnoreCase(value) || FALSE.equalsIgnoreCase(value)) : "Only true|false value is allowed.";
+		data.setVariable(InstallData.MODIFY_INSTALLATION, value.toLowerCase());
+	}
+	
+	public static Boolean get(IXMLElement panelRoot) {
+		IXMLElement oldVal = panelRoot.getFirstChildNamed(InstallData.MODIFY_INSTALLATION.toUpperCase());
+		if (oldVal != null && oldVal.getContent() != null && TRUE.equalsIgnoreCase(oldVal.getContent().trim())) {
+			return Boolean.TRUE;
+		}
+		IXMLElement newVal = panelRoot.getFirstChildNamed(InstallData.MODIFY_INSTALLATION.toLowerCase());
+		if (newVal != null && newVal.getContent() != null && TRUE.equalsIgnoreCase(newVal.getContent().trim())) {
+			return Boolean.TRUE;
+		}
+		return Boolean.FALSE;
+	}
+
+	public static Boolean get(InstallData data) {
+		return TRUE.equalsIgnoreCase(data.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase()))
+				|| TRUE.equalsIgnoreCase(data.getVariable(InstallData.MODIFY_INSTALLATION.toLowerCase()));
+	}
+}

--- a/izPackCustomActions/src/com/sage/izpack/MongoDBDataValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/MongoDBDataValidator.java
@@ -212,7 +212,8 @@ public class MongoDBDataValidator implements DataValidator {
 
 	@Override
 	public boolean getDefaultAnswer() {
-		return false;
+		// warning means that DB is already configured, can be ignored
+		return Boolean.TRUE;
 	}
 
 }

--- a/izPackCustomActions/src/com/sage/izpack/MongoDBDataValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/MongoDBDataValidator.java
@@ -57,7 +57,7 @@ public class MongoDBDataValidator implements DataValidator {
 		Status bReturn = Status.OK;
 		try {
 
-			Boolean modifyinstallation = Boolean.valueOf(adata.getVariable(InstallData.MODIFY_INSTALLATION));
+			Boolean modifyinstallation = ModifyInstallationUtil.get(adata);
 
 			// String userName = adata.getVariable("mongodb.url.username");
 			// String passWord = adata.getVariable("mongodb.url.password");

--- a/izPackCustomActions/src/com/sage/izpack/PortDataValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/PortDataValidator.java
@@ -25,7 +25,9 @@ public class PortDataValidator implements DataValidator {
 		// if update mode
 		// load old value
 
-		boolean updatemode = ("true".equalsIgnoreCase(adata.getVariable("MODIFY.IZPACK.INSTALL")));
+		// izpack5 changed this to low case, we read both to be compatible with version 4 & 5
+		boolean updatemode = ("true".equalsIgnoreCase(adata.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase()))
+				|| "true".equalsIgnoreCase(adata.getVariable(InstallData.MODIFY_INSTALLATION)));
 
 		if (updatemode) {
 			// load old installadata

--- a/izPackCustomActions/src/com/sage/izpack/PortDataValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/PortDataValidator.java
@@ -25,9 +25,7 @@ public class PortDataValidator implements DataValidator {
 		// if update mode
 		// load old value
 
-		// izpack5 changed this to low case, we read both to be compatible with version 4 & 5
-		boolean updatemode = ("true".equalsIgnoreCase(adata.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase()))
-				|| "true".equalsIgnoreCase(adata.getVariable(InstallData.MODIFY_INSTALLATION)));
+		boolean updatemode = ModifyInstallationUtil.get(adata);
 
 		if (updatemode) {
 			// load old installadata

--- a/izPackCustomActions/src/com/sage/izpack/PortValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/PortValidator.java
@@ -36,7 +36,7 @@ public class PortValidator implements DataValidator, com.izforge.izpack.panels.u
         int numfields = client.getNumFields();
         List<String> exludedPorts = new ArrayList<String>();
         
-		boolean modifyinstallation = Boolean.valueOf(this.installData.getVariable(InstallData.MODIFY_INSTALLATION));
+		boolean modifyinstallation = ModifyInstallationUtil.get(installData);
 
 		// VariableSubstitutor substitutor = new VariableSubstitutorImpl(this.installData.getVariables());
 

--- a/izPackCustomActions/src/com/sage/izpack/PostValidateSSLRedoAction.java
+++ b/izPackCustomActions/src/com/sage/izpack/PostValidateSSLRedoAction.java
@@ -10,7 +10,10 @@ public class PostValidateSSLRedoAction implements PanelAction {
 	@Override
 	public void executeAction(final InstallData adata, AbstractUIHandler handler) {
 		String strRedoSSL = adata.getVariable("MONGODB.SSL.REDO");
-		String strUpdate = adata.getVariable("MODIFY.IZPACK.INSTALL");
+		String strUpdate = adata.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase());
+		if (strUpdate == null || strUpdate.trim().equals("")) {
+			strUpdate = adata.getVariable(InstallData.MODIFY_INSTALLATION);
+		}
 		String strSSLAlreadyDone = adata.getVariable("mongodb.ssl.alreadydone");
 
 		if ("true".equalsIgnoreCase(strUpdate) && "true".equalsIgnoreCase(strRedoSSL)

--- a/izPackCustomActions/src/com/sage/izpack/PostValidateSSLRedoAction.java
+++ b/izPackCustomActions/src/com/sage/izpack/PostValidateSSLRedoAction.java
@@ -10,13 +10,10 @@ public class PostValidateSSLRedoAction implements PanelAction {
 	@Override
 	public void executeAction(final InstallData adata, AbstractUIHandler handler) {
 		String strRedoSSL = adata.getVariable("MONGODB.SSL.REDO");
-		String strUpdate = adata.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase());
-		if (strUpdate == null || strUpdate.trim().equals("")) {
-			strUpdate = adata.getVariable(InstallData.MODIFY_INSTALLATION);
-		}
+		boolean update = ModifyInstallationUtil.get(adata);
 		String strSSLAlreadyDone = adata.getVariable("mongodb.ssl.alreadydone");
 
-		if ("true".equalsIgnoreCase(strUpdate) && "true".equalsIgnoreCase(strRedoSSL)
+		if (update && "true".equalsIgnoreCase(strRedoSSL)
 				&& "true".equalsIgnoreCase(strSSLAlreadyDone)) {
 			// we want to redo ssl configuration
 			// set mongodb.ssl.alreadydone to false

--- a/izPackCustomActions/src/com/sage/izpack/PreValidatePacksPanelAction.java
+++ b/izPackCustomActions/src/com/sage/izpack/PreValidatePacksPanelAction.java
@@ -31,7 +31,7 @@ public class PreValidatePacksPanelAction implements com.izforge.izpack.data.Pane
 		// well if in modify mode
 		// then we must select already installed packs
 
-		boolean modifyinstallation = Boolean.valueOf(installData.getVariable(InstallData.MODIFY_INSTALLATION));
+		boolean modifyinstallation = ModifyInstallationUtil.get(installData);
 		this.installedpacks = new HashMap<String, com.izforge.izpack.Pack>();
 		HashMap<String, com.izforge.izpack.api.data.Pack> installedpacksBis = new HashMap<String, com.izforge.izpack.api.data.Pack>();
 		if (modifyinstallation) {

--- a/izPackCustomActions/src/com/sage/izpack/UpdateListener.java
+++ b/izPackCustomActions/src/com/sage/izpack/UpdateListener.java
@@ -84,7 +84,7 @@ public class UpdateListener extends AbstractProgressInstallerListener { // imple
 		try {
 			super.afterPacks(packs, listener);
 
-			if (Boolean.valueOf(this.getInstallData().getVariable(InstallData.MODIFY_INSTALLATION))) {
+			if (ModifyInstallationUtil.get(getInstallData())) {
 				// at the top i imagine a first general action script
 				// let says beforeUpdate Script
 
@@ -117,7 +117,7 @@ public class UpdateListener extends AbstractProgressInstallerListener { // imple
 			// super.afterPack(pack, i, handler);
 			super.afterPack(pack);
 
-			if (Boolean.valueOf(getInstallData().getVariable(InstallData.MODIFY_INSTALLATION))) {
+			if (ModifyInstallationUtil.get(getInstallData())) {
 				// fetchAndExcuteResource(pack.id + "_" + AFTER_UPDATE_SCRIPT + "_" + PLATFORM,
 				// getInstallData());
 				fetchAndExecuteResource(pack.getLangPackId() + "_" + AFTER_UPDATE_SCRIPT + "_" + PLATFORM, null,
@@ -176,7 +176,7 @@ public class UpdateListener extends AbstractProgressInstallerListener { // imple
 
 	private void beforePacksCommon() throws Exception {
 		// if (Boolean.valueOf(idata.getVariable(InstallData.MODIFY_INSTALLATION)))
-		if (Boolean.valueOf(getInstallData().getVariable(InstallData.MODIFY_INSTALLATION))) {
+		if (ModifyInstallationUtil.get(getInstallData())) {
 			// at the top i imagine a first general action script
 			// let says beforeUpdate Script
 

--- a/izPackCustomActions/src/com/sage/izpack/UpdatePassphraseValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/UpdatePassphraseValidator.java
@@ -28,14 +28,9 @@ public class UpdatePassphraseValidator implements DataValidator {
 	public Status validateData(InstallData adata) {
 		Status sreturn = Status.OK;
 
-		boolean updateMode = false;
+		boolean updateMode = ModifyInstallationUtil.get(adata);
 		boolean createCertificate = true;
 
-		if (adata.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase()) != null) {
-			updateMode = adata.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase()).equalsIgnoreCase("true");
-		} else if (adata.getVariable(InstallData.MODIFY_INSTALLATION) != null){
-			updateMode = adata.getVariable(InstallData.MODIFY_INSTALLATION).equalsIgnoreCase("true");
-		}
 		if (adata.getVariable("syracuse.certificate.install") != null)
 			createCertificate = adata.getVariable("syracuse.certificate.install").equalsIgnoreCase("true");
 

--- a/izPackCustomActions/src/com/sage/izpack/UpdatePassphraseValidator.java
+++ b/izPackCustomActions/src/com/sage/izpack/UpdatePassphraseValidator.java
@@ -31,8 +31,11 @@ public class UpdatePassphraseValidator implements DataValidator {
 		boolean updateMode = false;
 		boolean createCertificate = true;
 
-		if (adata.getVariable("MODIFY.IZPACK.INSTALL") != null)
-			updateMode = adata.getVariable("MODIFY.IZPACK.INSTALL").equalsIgnoreCase("true");
+		if (adata.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase()) != null) {
+			updateMode = adata.getVariable(InstallData.MODIFY_INSTALLATION.toUpperCase()).equalsIgnoreCase("true");
+		} else if (adata.getVariable(InstallData.MODIFY_INSTALLATION) != null){
+			updateMode = adata.getVariable(InstallData.MODIFY_INSTALLATION).equalsIgnoreCase("true");
+		}
 		if (adata.getVariable("syracuse.certificate.install") != null)
 			createCertificate = adata.getVariable("syracuse.certificate.install").equalsIgnoreCase("true");
 


### PR DESCRIPTION
changed CertManagerDataValidator to only set variables when generating new certificate, when copying from mongo installation leave them as-is.
added fallback's for izpack4 - var modify.izpack.install changed case in new version, we read both to support upgrading from izpack 4 -> 5
MongoDBDataValidator always throws warning about "syracuse" db already existing, its ok to ignore it during unattended install