### PR TITLE
fix(X3-319162): fix InstallationInformationHelper

### DIFF
--- a/izPackCustomActions/src/com/sage/izpack/InstallationInformationHelper.java
+++ b/izPackCustomActions/src/com/sage/izpack/InstallationInformationHelper.java
@@ -2,12 +2,10 @@ package com.sage.izpack;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Pack;
@@ -34,7 +32,7 @@ public final class InstallationInformationHelper {
 
     private static boolean isLegacyIzpack = false;
 
-    public static boolean hasAlreadyReadInformation(com.izforge.izpack.api.data.InstallData installData) {
+    public static boolean hasAlreadyReadInformation(InstallData installData) {
         boolean hasRead = Boolean.parseBoolean(installData.getVariable(ALREADY_LOADED));
         logger.log(Level.FINE, logPrefix + "hasAlreadyReadInformation : " + hasRead);
         return hasRead;
@@ -77,95 +75,71 @@ public final class InstallationInformationHelper {
             logger.log(Level.FINE, logPrefix + "Installation information loading failed: " + e.getMessage());
             informationloaded = false;
         }
-        // If old version 4.3.8, ...
-        if (!informationloaded) {
-            logger.log(Level.FINE, logPrefix + "Loading legacy installation information");
-            try {
-                informationloaded = loadLegacyInstallationInformation(installData);
-                logger.log(Level.FINE, logPrefix + "Legacy installation information loaded");
-            } catch (Exception e) {
-                logger.log(Level.FINE, logPrefix + "Installation legacy information loading failed: " + e.getMessage());
-                informationloaded = false;
-            }
-        }
         installData.setVariable(ALREADY_LOADED, Boolean.toString(informationloaded));
     }
 
     public static boolean isIncompatibleInstallation(String installPath, boolean isReadInstallationInformation) {
-
-        boolean result = false;
         String logHeader = "InstallationInformationHelper.isIncompatibleInstallation - ";
         if (isReadInstallationInformation) {
-
-            ObjectInputStream oin = null;
             File installInfo = new File(installPath, InstallData.INSTALLATION_INFORMATION);
             if (installInfo.exists()) {
-                FileInputStream fin;
-                List<Pack> packsinstalled;
-                try {
-                    fin = new FileInputStream(installInfo);
-                    oin = new ObjectInputStream(fin);
-                    // noinspection unchecked
-                    packsinstalled = (List<Pack>) oin.readObject();
-
-                    for (Pack installedpack : packsinstalled) {
-                        logger.log(Level.FINE, logHeader + "pack " + installedpack.getName());
-                    }
-                    logger.log(Level.FINE, logHeader + "Found " + packsinstalled.size() + " installed packs");
-                } catch (Exception e) {
-                    result = true;
-                    logger.warning(logHeader + "Could not read Pack installation information: " + e.getMessage());
-                }
-
-                // Previous version of izPack 4.3
-                if (result) {
-
-                    try {
-                        fin = new FileInputStream(installInfo);
-                        oin = new ObjectInputStream(fin);
-                        // noinspection unchecked
-                        List<com.izforge.izpack.Pack> packsinstalled2 = (List<com.izforge.izpack.Pack>) oin.readObject();
-
-                        for (com.izforge.izpack.Pack installedpack : packsinstalled2) {
-                            logger.log(Level.FINE, logHeader + "installedpack: " + installedpack.name);
+                try (ObjectInputStream oin = new ObjectInputStream(new FileInputStream(installInfo))) {
+                    // noinspection rawtypes
+                    List objects = (List) oin.readObject();
+                    for (Object pack : objects) {
+                        if (pack instanceof com.izforge.izpack.Pack) {
+                            logger.log(Level.FINE, logHeader + "found legacy pack: " + ((com.izforge.izpack.Pack) pack).name);
+                        } else if (pack instanceof com.izforge.izpack.api.data.Pack) {
+                            logger.log(Level.FINE, logHeader + "found pack: "+ ((com.izforge.izpack.api.data.Pack)pack).getName());
+                        } else {
+                            return Boolean.TRUE;
                         }
-                        logger.log(Level.FINE, logHeader + "Found Legacy " + packsinstalled2.size() + " installed packs");
-                        result = false;
-                    } catch (Exception e) {
-                        logger.warning(logHeader + "Could not read Legacy 'Pack' installation information: " + e.getMessage());
                     }
-                }
-            }
-
-            if (oin != null) {
-                try {
-                    oin.close();
-                } catch (IOException ignored) {
+                    Properties props = (Properties) oin.readObject();
+                    for (String key : props.stringPropertyNames()) {
+                        logger.log(Level.FINE, logHeader + "found variable: " + key + " = " + props.getProperty(key));
+                    }
+                } catch (Exception ignored) {
+                    logger.log(Level.SEVERE, logHeader + "problem reading "+installInfo.getAbsolutePath());
+                    return Boolean.TRUE;
                 }
             }
         }
-        logger.log(Level.FINE, logPrefix + "isIncompatibleInstallation returns " + result);
-
-        return result;
+        return Boolean.FALSE;
     }
 
-    private static boolean loadInstallationInformation(com.izforge.izpack.api.data.InstallData installData) {
-
+    private static boolean loadInstallationInformation(InstallData installData) {
         File installInfo = new File(installData.getInstallPath(), InstallData.INSTALLATION_INFORMATION);
         if (!installInfo.exists()) {
             logger.log(Level.FINE, logPrefix + installInfo.getAbsolutePath() + " doesnt exist, exiting.");
             return Boolean.FALSE;
         }
         try (ObjectInputStream oin = new ObjectInputStream(new FileInputStream(installInfo))) {
-            // noinspection unchecked
-            List<com.izforge.izpack.api.data.Pack> packsinstalled = (List<com.izforge.izpack.api.data.Pack>) oin.readObject();
+            // noinspection rawtypes
+            List packsinstalled = (List) oin.readObject();
             logger.log(Level.FINE, logPrefix + "Found " + packsinstalled.size() + " installed packs");
 
-            List<Pack> selectedPacks = new ArrayList<>(installData.getSelectedPacks());
-            selectedPacks.addAll(installData.getAvailablePacks().stream()
-                        .filter(p->containsPack(p, packsinstalled))
-                        .filter(p->!containsPack(p, installData.getSelectedPacks()))
-                        .collect(Collectors.toList()));
+            final List<Pack> selectedPacks = new ArrayList<>(installData.getSelectedPacks());
+            for (Object obj : packsinstalled) {
+                if (obj instanceof com.izforge.izpack.Pack) {
+                    isLegacyIzpack = Boolean.TRUE;
+                    final com.izforge.izpack.Pack pack = (com.izforge.izpack.Pack) obj;
+                    installData.getAvailablePacks().stream()
+                        .filter(p -> p.getName().equals(pack.name))
+                        .filter(p -> notContainsPack(pack.name, selectedPacks))
+                        .findFirst()
+                        .ifPresent(selectedPacks::add);
+                } else if (obj instanceof com.izforge.izpack.api.data.Pack) {
+                    final com.izforge.izpack.api.data.Pack pack = (com.izforge.izpack.api.data.Pack) obj;
+                    installData.getAvailablePacks().stream()
+                        .filter(p -> p.getName().equals(pack.getName()))
+                        .filter(p -> notContainsPack(pack.getName(), selectedPacks))
+                        .findFirst()
+                        .ifPresent(selectedPacks::add);
+                } else {
+                    return Boolean.FALSE;
+                }
+            }
             installData.setSelectedPacks(selectedPacks);
 
             Properties variables = (Properties) oin.readObject();
@@ -181,72 +155,10 @@ public final class InstallationInformationHelper {
         }
     }
 
-    private static boolean containsPack(Pack p, List<Pack> packs) {
+    private static boolean notContainsPack(String name, List<Pack> packs) {
         Optional<Pack> found = packs.stream()
-            .filter(a -> p.getName().equals(a.getName()))
+            .filter(p -> name.equals(p.getName()))
             .findFirst();
-        return found.isPresent();
+        return found.isEmpty();
     }
-
-    private static boolean loadLegacyInstallationInformation(com.izforge.izpack.api.data.InstallData installData) {
-
-        File installInfo = new File(installData.getInstallPath(), InstallData.INSTALLATION_INFORMATION);
-        if (!installInfo.exists()) {
-            logger.log(Level.FINE, logPrefix + installInfo.getAbsolutePath() + " doesnt exist, exiting.");
-            return Boolean.FALSE;
-        }
-        String logHeader = logPrefix + "loadLegacyInstallationInformation - ";
-        try (ObjectInputStream oin = new ObjectInputStream(new FileInputStream(installInfo))) {
-
-            Object variablesObject = oin.readObject();
-            while (variablesObject != null) {
-                logger.log(Level.FINE, logHeader + "readObject legacy type:" + variablesObject.getClass().getName());
-
-                if (variablesObject instanceof Properties) {
-                    Properties variables = (Properties) variablesObject;
-                    for (Object key : variables.keySet()) {
-                        if (!VARIABLES_EXCEPTIONS.contains((String) key)) {
-                            installData.setVariable((String) key, (String) variables.get(key));
-                        }
-                    }
-                }
-                if (variablesObject instanceof ArrayList) {
-                    //noinspection rawtypes
-                    readLegacyPackages(installData, (ArrayList) variablesObject);
-                }
-                variablesObject = oin.readObject();
-            }
-
-            logger.log(Level.FINE, logHeader + "writeInstallationInformation to fix legacy issue");
-
-            // X3-256055: Uninstaller (izpack 5.2)
-            installData.setVariable("force-generate-uninstaller", "true");
-            logger.log(Level.FINE, logHeader + "force-generate-uninstaller set to true");
-
-            isLegacyIzpack = true;
-            return Boolean.TRUE;
-        } catch (Exception e) {
-            logger.warning(logHeader + "Could not read Legacy 'Properties' installation information: " + e.getMessage());
-            return Boolean.FALSE;
-        }
-    }
-
-    private static void readLegacyPackages(com.izforge.izpack.api.data.InstallData installData, @SuppressWarnings("rawtypes") ArrayList variables) {
-        logger.log(Level.FINE, "readVariables ArrayList objects: " + variables + " : " + variables.getClass().getName());
-        List<com.izforge.izpack.api.data.Pack> packLists = new ArrayList<>(installData.getSelectedPacks());
-        for (Object key : variables) {
-            logger.log(Level.FINE, "keyType:" + key.getClass().getName());
-            if (key instanceof com.izforge.izpack.Pack) {
-                com.izforge.izpack.Pack theFormerPack = (com.izforge.izpack.Pack) key;
-                installData.getAvailablePacks().stream()
-                    .filter(p -> p.getName().equals(theFormerPack.name))
-                    .filter(p -> !containsPack(p, installData.getSelectedPacks()))
-                    .findFirst()
-                    .ifPresent(packLists::add);
-            }
-        }
-        if (!packLists.isEmpty())
-            installData.setSelectedPacks(new ArrayList<>(packLists));
-    }
-
 }


### PR DESCRIPTION
This has been tested on .installationinformation from:
* clean izpack 4 installation
* clean izpack 5 installation
* upgrade from 4 to 5
* broken installation containing info from both izpack 4 and izpack 5